### PR TITLE
Update t81_558_class5_backpropagation.ipynb

### DIFF
--- a/t81_558_class5_backpropagation.ipynb
+++ b/t81_558_class5_backpropagation.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "$ v_t = \\eta \\nabla_{\\theta_{t-1}} J(\\theta_{t-1}) + \\lambda v_{t-1} $\n",
     "\n",
-    "Like the learning rate, momentum adds another training parameter that scales the effect of momentum.  Momentum backpropagation has two training parameters: learning rate ($\\lambda$) and momentum ($\\eta$).  Momentum simply adds the scaled value of the previous weight change amount ($v_{t-1}$) to the current weight change amount($v_t$).\n",
+    "Like the learning rate, momentum adds another training parameter that scales the effect of momentum.  Momentum backpropagation has two training parameters: learning rate ($\\eta$) and momentum ($\\lambda$).  Momentum simply adds the scaled value of the previous weight change amount ($v_{t-1}$) to the current weight change amount($v_t$).\n",
     "\n",
     "This has the effect of adding additional force behind a direction a weight was moving.  This might allow the weight to escape a local minima:\n",
     "\n",


### PR DESCRIPTION
I think you accidentally switched the notation for learning rate and momentum.