### PR TITLE
Fix 2D matrix encoding error in MPG regression

### DIFF
--- a/t81_558_class2_tensor_flow.ipynb
+++ b/t81_558_class2_tensor_flow.ipynb
@@ -2838,7 +2838,7 @@
     "df\n",
     "\n",
     "# Encode to a 2D matrix for training\n",
-    "x,y = to_xy(df,['mpg'])\n",
+    "x,y = to_xy(df,'mpg')\n",
     "\n",
     "# Get/clear a directory to store the neural network to\n",
     "model_dir = get_model_dir('mpg',True)\n",


### PR DESCRIPTION
The function to_xy is still returning the mpg column for x if ['mpg'] is passed instead of 'mpg'.
This leads to the network being trained with the response variable.