### PR TITLE
Corrected "model.fit()" parameters

### DIFF
--- a/t81_558_class12_security.ipynb
+++ b/t81_558_class12_security.ipynb
@@ -944,7 +944,7 @@
     "model.add(Dense(y.shape[1],activation='softmax'))\n",
     "model.compile(loss='categorical_crossentropy', optimizer='adam')\n",
     "monitor = EarlyStopping(monitor='val_loss', min_delta=1e-3, patience=5, verbose=1, mode='auto')\n",
-    "model.fit(x,y,validation_data=(x_test,y_test),callbacks=[monitor],verbose=2,epochs=1000)\n",
+    "model.fit(x_train,y_train,validation_data=(x_test,y_test),callbacks=[monitor],verbose=2,epochs=1000)\n",
     "        "
    ]
   },


### PR DESCRIPTION
The 1st and 2nd parameters passed to "model.fit()" were the whole dataset (x, y, ...), whereas it should be only the training part (x_train, y_train).

@jeffheaton