### PR TITLE
Line169: Wrong Filter Size in Brackets

### DIFF
--- a/t81_558_class_06_2_cnn.ipynb
+++ b/t81_558_class_06_2_cnn.ipynb
@@ -163,7 +163,7 @@
     "[FilterSize] * [FilterSize] * [# of Filters]\n",
     "```\n",
     "\n",
-    "For example, if the filter size were 5 (5x4) for 10 filters, there would be 250 weights.\n",
+    "For example, if the filter size were 5 (5x5) for 10 filters, there would be 250 weights.\n",
     "\n",
     "You need to understand how the convolutional filters sweep across the previous layer’s output or image grid. Figure 10.2 illustrates the sweep:\n",
     "\n",


### PR DESCRIPTION
Changed Line 169
before:  "For example, if the filter size were 5 (4x5) for 10 filters, there would be 250 weights.\n"
after:  "For example, if the filter size were 5 (5x5) for 10 filters, there would be 250 weights.\n"