### PR TITLE
tools.yml: Added pip as a dependancy

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -17,6 +17,7 @@ dependencies:
     - pyyaml
     - flask
     - boto3
+    - pip
     - pip:
         - bayesian-optimization
         - gym


### PR DESCRIPTION
The proposed change enabled me to avoid the following warning and complete the tensor flow installation:

```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies. Conda may not use the correct pip to install you packages, and they may end up in the wrong place. Please add an explicit pip dependency. I'm adding one for you, but still nagging you.
```

Without the change, the warning kept repeating and I could not progress past the "conda env update --file tools.yml
" command.

