### PR TITLE
Issue related to Kernel Crash addressed

### DIFF
--- a/install/tensorflow-install-mac-metal-jul-2021.ipynb
+++ b/install/tensorflow-install-mac-metal-jul-2021.ipynb
@@ -102,6 +102,12 @@
     "\n",
     "We will actually launch Jupyter later.\n",
     "\n",
+    "First, we deactivate the base environment.\n",
+    "\n",    
+    "```\n",
+    "conda deactivate\n",
+    "```\n",
+    "\n"
     "Next, we will install the Mac M1 [tensorflow-apple-metal.yml](https://raw.githubusercontent.com/jeffheaton/t81_558_deep_learning/master/tensorflow-apple-metal.yml) file that I provide. Run the following command from the same directory that contains **tensorflow-apple-metal.yml**.\n",
     "\n",
     "```\n",


### PR DESCRIPTION
Added "conda deactivate" before the creation of 'tensorflow' environment. It addresses the issue of kernel crashing (dying) and kernel restarting.
- This is a continuation to the discussion that followed in the comment section of your video titled, "[2021, Installing TensorFlow 2.5, Keras, & Python 3.9 in Mac OSX M1.](https://www.youtube.com/watch?v=_CO-ND1FTOU)" Kevin David suggesting this solution to us and it worked. If you think that this addition would be useful to many, please accept the pull request.

Thanks.

- Amol