### PR TITLE
Add `conda init` step to install

### DIFF
--- a/install/tensorflow-install-mac-metal-jul-2021.ipynb
+++ b/install/tensorflow-install-mac-metal-jul-2021.ipynb
@@ -18,7 +18,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,6 +58,16 @@
     "```\n",
     "\n",
     "You should note which directory \n",
+    "\n",
+    "## Initiate Miniforge\n",
+    "\n",
+    "Run the following command to initiate your conda base environment:\n",
+    "\n",
+    "```\n",
+    "conda init\n",
+    "```\n",
+    "\n",
+    "This will set the python `PATH` to the Miniforge base in your profile (`~/.bash_profile` if bash or `~/.zshenv` if zsh) and create the base virtual environment.\n",
     "\n",
     "## Make Sure you Have the Correct Python (when things go wrong)\n",
     "\n",
@@ -103,7 +112,7 @@
     "We will actually launch Jupyter later.\n",
     "\n",
     "First, we deactivate the base environment.\n",
-    "\n",    
+    "\n",
     "```\n",
     "conda deactivate\n",
     "```\n",
@@ -182,10 +191,10 @@
       "Tensor Flow Version: 2.5.0\n",
       "Keras Version: 2.5.0\n",
       "\n",
-      "Python 3.9.6 | packaged by conda-forge | (default, Jul  6 2021, 08:51:19) \n",
+      "Python 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:24:02) \n",
       "[Clang 11.1.0 ]\n",
-      "Pandas 1.3.0\n",
-      "Scikit-Learn 0.24.2\n",
+      "Pandas 1.3.4\n",
+      "Scikit-Learn 1.0.1\n",
       "GPU is available\n"
      ]
     }
@@ -234,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Recently followed your installation instructions for M1, really appreciated 😀

Was missing one step, the `conda init` step after installing miniforge - I just installed for a brand new M1 as of Nov 21