### PR TITLE
Remove out of place sentence

### DIFF
--- a/t81_558_class_01_1_overview.ipynb
+++ b/t81_558_class_01_1_overview.ipynb
@@ -174,7 +174,7 @@
     "* [PyTorch](https://pytorch.org/) (Facebook)\n",
     "\n",
     "\n",
-    "Overall, this book focused on the application of deep neural networks. This book focuses primarily upon Keras, with some applications in PyTorch. For many tasks, we will utilize Keras directly. We will utilize third-party libraries for higher-level tasks, such as reinforcement learning, generative adversarial neural networks, and others. These third-party libraries may internally make use of either PyTorch or Keras. I chose these libraries based on popularity and application, not whether they used PyTorch or Keras.\n",
+    "This book focuses primarily upon Keras, with some applications in PyTorch. For many tasks, we will utilize Keras directly. We will utilize third-party libraries for higher-level tasks, such as reinforcement learning, generative adversarial neural networks, and others. These third-party libraries may internally make use of either PyTorch or Keras. I chose these libraries based on popularity and application, not whether they used PyTorch or Keras.\n",
     "\n",
     "To successfully use this book, you must be able to compile and execute Python code that makes use of TensorFlow for deep learning. There are two options for you to accomplish this:\n",
     "\n",


### PR DESCRIPTION
I just picked up this book and started reading it. If I find anything I can do PRs in bite size chunks. 

For this change, the section is talking about using TensorFlow and Pytorch, but th sentence after seems to be referencing what the book is about in general. I don't think it is needed. If you do keep it, "focused" probably needs to be changed to the present tense "focuses".